### PR TITLE
SRE-2981: Limit audit entries to 10 million

### DIFF
--- a/config/initializers/fix_audited.rb
+++ b/config/initializers/fix_audited.rb
@@ -1,3 +1,4 @@
 Audit = Audited::Adapters::ActiveRecord::Audit
+Audited.max_audits = 10_000_000
 #TODO: potential vulnarability
 Audit.attr_accessible :username, :user, :version, :auditable


### PR DESCRIPTION
This should limit how many audit entries we keep in the `audits` table.